### PR TITLE
Fixed logic to get the timer show time based on the milliseconds input.

### DIFF
--- a/panolibrary/src/main/java/com/martin/ads/vrlib/utils/UIUtils.java
+++ b/panolibrary/src/main/java/com/martin/ads/vrlib/utils/UIUtils.java
@@ -8,6 +8,7 @@ import com.example.panolibrary.R;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by xilin on 2015/12/14.
@@ -15,17 +16,13 @@ import java.util.Calendar;
 public class UIUtils
 {
     public static String getShowTime(long milliseconds) {
-        // 获取日历函数
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTimeInMillis(milliseconds);
-        SimpleDateFormat dateFormat = null;
-        // 判断是否大于60分钟，如果大于就显示小时。设置日期格式
-        if (milliseconds / 60000 > 60) {
-            dateFormat = new SimpleDateFormat("hh:mm:ss");
-        } else {
-            dateFormat = new SimpleDateFormat("00:mm:ss");
-        }
-        return dateFormat.format(calendar.getTime());
+
+        return String.format("%02d:%02d:%02d",
+                TimeUnit.MILLISECONDS.toHours(milliseconds),
+                TimeUnit.MILLISECONDS.toMinutes(milliseconds) -
+                        TimeUnit.HOURS.toMinutes(TimeUnit.MILLISECONDS.toHours(milliseconds)),
+                TimeUnit.MILLISECONDS.toSeconds(milliseconds) -
+                        TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(milliseconds)));
     }
 
     public static void startImageAnim(ImageView Img, int anim)


### PR DESCRIPTION
Setting the time in milliseconds to the Calender object was setting the milliseconds from the start time in 1970. That was causing the error of showing incorrect time in minutes and hours. Like when the video is of 2m duration, the timer started from 00:30:00 till 00:32:00. So, used the solution from [here](http://stackoverflow.com/a/9027379/3090120) to format the milliseconds into hh:mm:ss format. 